### PR TITLE
Security fixes for newer Chrome versions, as inline javascript is no longer allowed

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,4 +1,3 @@
-<script type="text/javascript">
 (function() {
 	localStorage.interval || (localStorage.interval = 120000);
 	localStorage.displayTime || (localStorage.displayTime = 15000);
@@ -10,14 +9,8 @@
 		xhr.onreadystatechange = function() {
 			if (xhr.readyState === 4) {
 				if (xhr.status === 200) {
-					container.innerHTML = xhr.responseText;
-					success(Array.prototype.slice.call(container.querySelectorAll('.list .item')).map(function(item, key) {
-						return {
-							image: item.querySelector('div.gravatar img').src,
-							title: item.querySelector('div.title').innerHTML,
-							content: item.querySelector('div.message').innerHTML
-						};
-					}));
+					notifications = parse_notifications(xhr.responseText);
+					success(notifications);
 				} else {
 					failure();
 				}
@@ -25,6 +18,21 @@
 		}
 		xhr.send();
 	}
+
+	function parse_notifications(responseText) {
+		container.innerHTML = responseText;
+		var notificationNodes = container.querySelectorAll('#notification-center .list-browser-item');
+		var notifications = Array.prototype.slice.call(notificationNodes).map(function(item, key) {
+			var item = {
+				image: item.querySelector('img.avatar').src,
+				title: item.querySelector('h4').innerText,
+				content: item.querySelector('h4').innerHTML
+			};
+			return item;
+		})
+		return notifications;
+	}
+
 	function notify(notification) {
 		var notification = webkitNotifications.createHTMLNotification(
 			'notification.html#image=' + encodeURIComponent(notification.image) +
@@ -34,6 +42,7 @@
 		notification.show();
 		localStorage.displayTime > 0 && setTimeout(function(){notification.cancel();}, localStorage.displayTime);
 	}
+
 	(function pull() {
 		get_notifications(function(notifications) {
 			if (localStorage.last_notification_content !== undefined) {
@@ -45,7 +54,9 @@
 				new_notifications.length && (localStorage.last_notification_content = new_notifications[0].content);
 				new_notifications.reverse().map(notify);
 			} else {
-				localStorage.last_notification_content = notifications[0].content;
+				if (notifications[0] !== undefined) {
+					localStorage.last_notification_content = notifications[0].content;
+				}
 			}
 			setTimeout(pull, localStorage.interval);
 		}, function() {
@@ -60,4 +71,3 @@
 		});
 	})();
 })();
-</script>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,10 +1,22 @@
 {
+  "manifest_version": 2,
   "name": "GitHub Notifications",
   "version": "0.5",
   "description":
     "Get notifications from GitHub to Chrome Desktop Notifications. https://github.com/shesek/github-notifications/",
   "icons": {"16": "16.png", "48": "48.png", "128": "128.png"},
-  "permissions": ["notifications", "https://github.com/"],
-  "background_page": "background.html",
+  "permissions": [
+    "background",
+    "notifications",
+    "alarms",
+    "storage",
+    "https://github.com/"
+  ],
+  "background": {
+    "persistent": true,
+    "scripts": [
+      "background.js"
+    ]
+  },
   "options_page": "options.html"
-} 
+}

--- a/src/notification.html
+++ b/src/notification.html
@@ -13,28 +13,7 @@
 			#content a.subject { font-weight: bold; }
 			#content a.body { color: #23486B; }
 		</style>
-		<script type="text/javascript">
-		window.addEventListener('load',function() {
-			document.location.hash.substr(1).split('&').forEach(function(nameval) {
-				nameval = nameval.split('=');
-				document.getElementById(nameval[0])[nameval[0]==='image' ? 'src' : 'innerHTML'] = decodeURIComponent(nameval[1]);
-			});
-			document.body.addEventListener('click', function(e) {
-				e.preventDefault();
-				// Links inside notifications aren't handlded by Chrome. To make them work, catch
-				// the clicks manually and open using window.open()
-				if (e.target.tagName === 'A') { // When a link is clicked, use its href
-					var href = e.target.getAttribute('href');
-				// Clicking in the notification area, but not on a specific link, opens the first
-				// link in the content area, which is the primary link.
-				} else {
-					var href = document.querySelector('#content a').href;
-				}
-				window.open(href.indexOf('/') === 0 ? 'https://github.com' + href : href);
-				window.close();
-			}, false);
-		}, false);
-		</script>
+		<script src="notification.js"></script>
 	</head>
 	<body>
 		<img id="image" />

--- a/src/notification.js
+++ b/src/notification.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded',function(e) {
+  document.location.hash.substr(1).split('&').forEach(function(nameval) {
+    nameval = nameval.split('=');
+    document.getElementById(nameval[0])[nameval[0]==='image' ? 'src' : 'innerHTML'] = decodeURIComponent(nameval[1]);
+  });
+  document.body.addEventListener('click', function(e) {
+    e.preventDefault();
+    // Links inside notifications aren't handlded by Chrome. To make them work, catch
+    // the clicks manually and open using window.open()
+    if (e.target.tagName === 'A') { // When a link is clicked, use its href
+      var href = e.target.getAttribute('href');
+    // Clicking in the notification area, but not on a specific link, opens the first
+    // link in the content area, which is the primary link.
+    } else {
+      var href = document.querySelector('#content a').href;
+    }
+    window.open(href.indexOf('/') === 0 ? 'https://github.com' + href : href);
+    window.close();
+  }, false);
+});

--- a/src/options.html
+++ b/src/options.html
@@ -11,19 +11,7 @@
 			p { margin-bottom: 0.5em; }
 			input[type=submit] { padding: 0.3em; }
 		</style>
-		<script type="text/javascript">
-		window.addEventListener('load',function(e) {
-			document.getElementById('interval').value = localStorage.interval / 1000;
-			document.getElementById('display-time').value = localStorage.displayTime / 1000;
-			document.getElementsByTagName('form')[0].addEventListener('submit', function() {
-				localStorage.interval = (parseInt(document.getElementById('interval').value) || 120) * 1000;
-				localStorage.displayTime = (parseInt(document.getElementById('display-time').value) || 15) * 1000;
-				document.getElementById('message').style.display = 'block';
-				e.preventDefault();
-				return false;
-			}, false);
-		}, false);
-		</script>
+		<script src="options.js"></script
 	</head>
 	<body>
 		<h1>GitHub Notifications Options</h1>

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded',function(e) {
+  document.getElementById('interval').value = localStorage.interval / 1000;
+  document.getElementById('display-time').value = localStorage.displayTime / 1000;
+  document.getElementsByTagName('form')[0].addEventListener('submit', function() {
+    localStorage.interval = (parseInt(document.getElementById('interval').value) || 120) * 1000;
+    localStorage.displayTime = (parseInt(document.getElementById('display-time').value) || 15) * 1000;
+    document.getElementById('message').style.display = 'block';
+    e.preventDefault();
+    return false;
+  }, false);
+});


### PR DESCRIPTION
This makes the code compatible with Chrome 26 and latest Github changes.

Some nicer notification styling would probably be a nice touch, but leaving that for now.
